### PR TITLE
Added missing closing quote that was breaking captcha button

### DIFF
--- a/App/StackExchange.DataExplorer/Views/Shared/Captcha.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Shared/Captcha.cshtml
@@ -19,5 +19,5 @@
             <strong>Error:</strong> looks like you typed in the wrong words - try again
         </p>
     </div>
-    <input id="btn-captcha" style="font-weight:bold; type="button" name="submit-captcha" value="&nbsp;I'm a Human Being&nbsp;"/><br>
+    <input id="btn-captcha" style="font-weight:bold;" type="button" name="submit-captcha" value="&nbsp;I'm a Human Being&nbsp;"/><br>
 </div>


### PR DESCRIPTION
Might have [jumped the gun a bit](http://meta.stackoverflow.com/questions/149328/why-is-there-a-textbox-instead-of-a-button-in-data-explorers-captcha) on that `status-completed`, but here we go.
