### PR TITLE
Optionally attempt to grab [Post Link] titles for tag wiki posts

### DIFF
--- a/App/StackExchange.DataExplorer/AppSettings.cs
+++ b/App/StackExchange.DataExplorer/AppSettings.cs
@@ -46,6 +46,9 @@ namespace StackExchange.DataExplorer
         [Default(true)]
         public static bool EnableCancelQuery { get; private set; }
 
+        [Default(false)]
+        public static bool EnableTagWikiTitleLookup { get; private set; }
+
         [Default("")]
         public static string RecaptchaPublicKey { get; private set; }
 


### PR DESCRIPTION
Per http://meta.stackoverflow.com/q/161063. Since the data dumps currently lack this information, it has to be enabled as a site setting to avoid conflicts with a non-compatible schema.
