### PR TITLE
Fixed inevitable NPE when changing OpenID on a non-merged account

### DIFF
--- a/App/StackExchange.DataExplorer/Controllers/AccountController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/AccountController.cs
@@ -152,7 +152,7 @@ namespace StackExchange.DataExplorer.Controllers
                             // work on allowing multiple OpenID logins, but for now I'll settle for not throwing an exception...
                             if (!currentOpenIds.Any(s => s.OpenIdClaim == normalizedClaim))
                             {
-                                Current.DB.UserOpenIds.Update(openId.Id, new { OpenIdClaim = normalizedClaim });
+                                Current.DB.UserOpenIds.Update(currentOpenIds.First().Id, new { OpenIdClaim = normalizedClaim });
                             }
                           
                             user = CurrentUser;


### PR DESCRIPTION
Prevent the [server from sad-facing](http://meta.stackoverflow.com/questions/161423). Will look at cleaning up the whole OpenID mess here in the near future.
