### PR TITLE
Fixed SlickGrid event not being hooked up correctly to prevent exception on column resize

### DIFF
--- a/App/StackExchange.DataExplorer/Scripts/query.js
+++ b/App/StackExchange.DataExplorer/Scripts/query.js
@@ -897,7 +897,7 @@ DataExplorer.ready(function () {
         });
 
         grid = new Slick.Grid(target, rows, columns, options);
-        grid.onColumnsResized = resizeResults;
+        grid.onColumnsResized.subscribe(resizeResults);
     }
 
     function ColumnFormatter(response) {


### PR DESCRIPTION
Helps if you read the documentation, whoops.
