### PR TITLE
Change jQuery CDN to Google for consistency with the rest of the network

### DIFF
--- a/App/StackExchange.DataExplorer/AssetPackager.cs
+++ b/App/StackExchange.DataExplorer/AssetPackager.cs
@@ -93,7 +93,7 @@ namespace StackExchange.DataExplorer
                         }
                     },
                     {
-                        "jquery", new AssetCollection("http://ajax.microsoft.com/ajax/jquery/jquery-1.7.1.min.js")
+                        "jquery", new AssetCollection("//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js")
                         {
                             "/Scripts/jquery-1.7.1.js"
                         }


### PR DESCRIPTION
Just because [someone complained about it](http://meta.stackoverflow.com/questions/175643/allowing-javascript-from-domain-microsoft-com-on-stack-exchange-data-explorer-s).
