### PR TITLE
Moved last update date to header and size stats columns

### DIFF
--- a/App/StackExchange.DataExplorer/Content/homepage.css
+++ b/App/StackExchange.DataExplorer/Content/homepage.css
@@ -39,10 +39,20 @@
   font-size: 22px;
   margin-left: 16px;
   color: #0C57A0;
+  width: 80px;
 }
 
 .site-list li .stats li.link {
   font-size: 12px;
+  text-align: right;
+}
+
+.site-list li .stats li.link a, .site-list li .stats li.link a:visited {
+  color: #909090;
+}
+
+.site-list li .stats li.link a:hover {
+  color: #07C;
 }
 
 .site-list li .stats li .relativetime {
@@ -55,4 +65,15 @@
   font-size: 12px;
   color: #909090;
   padding-top: 2px;
+}
+
+.info-wrapper {
+  position: relative;
+}
+
+.info-wrapper .info {
+  position: absolute;
+  right: 0;
+  top: -39px;
+  color: #909090;
 }

--- a/App/StackExchange.DataExplorer/Controllers/HomeController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/HomeController.cs
@@ -18,6 +18,8 @@ namespace StackExchange.DataExplorer.Controllers
 
             var sites = Current.DB.Query<Models.Site>("select * from Sites order by TotalQuestions desc").ToList();
 
+            ViewData["LastUpdate"] = Current.DB.Query<DateTime?>("SELECT MAX(LastPost) FROM Sites").FirstOrDefault();
+
             return View(sites);
         }
 

--- a/App/StackExchange.DataExplorer/Views/Home/Index.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Home/Index.cshtml
@@ -2,6 +2,9 @@
 @using StackExchange.DataExplorer.Models
 @{this.SetPageTitle("Stack Exchange Data Explorer");}
 <div id="mainbar-full">
+    <div class="info-wrapper">
+        <span class="info">Data updated @((ViewData["LastUpdate"] as DateTime?).ToRelativeTime())</span>
+    </div>
     <ul class="site-list">
     @foreach (Site site in Model)
     {
@@ -31,10 +34,6 @@
                 <li>
                     @Html.Raw(site.TotalTags.PrettyShort())
                     <span class="desc">tags</span>
-                </li>
-                <li>
-                    @site.LastPost.ToRelativeTimeSpanMicro()
-                    <span class="desc">most recent</span>
                 </li>
                 <li class="link">
                     <a href="@site.Url">visit site <i class="icon-arrow-right"></i></a>


### PR DESCRIPTION
The last update date is now in the header on the homepage, with a more clear description:

![Repositioned update date](https://f.cloud.github.com/assets/449006/1982045/03779a38-83ef-11e3-8807-6e37ab267acb.png)

Stats columns are now also a fixed size, and the visit link is subdued/right-aligned.
