### PR TITLE
Fix .gitignore to not ignore package DLLs in the future

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ App/_ReSharper.DataExplorerFull/
 *.itrace.csdef
 App/TestResults/
 PublishProfiles/
+!App/packages/**/lib/**/*.dll


### PR DESCRIPTION
...Since this has happened before. Does committing the packages make the most sense, or should the build be modified to just pull what's in the packages.config file automatically?
