### PR TITLE
Check for X-Forwarded-Proto header to make sure reCAPTCHA is configured correctly

### DIFF
--- a/App/StackExchange.DataExplorer/Current.cs
+++ b/App/StackExchange.DataExplorer/Current.cs
@@ -29,6 +29,12 @@ namespace StackExchange.DataExplorer
             control.PublicKey = AppSettings.RecaptchaPublicKey;
             control.Theme = "clean";
 
+            if (!Context.Request.IsSecureConnection)
+            {
+                var forwarded = Context.Request.Headers["X-Forwarded-Proto"];
+                control.OverrideSecureMode = forwarded != null && forwarded.StartsWith("https");
+            }
+
             return control;
         }
 


### PR DESCRIPTION
Addresses [this meta post](http://meta.stackoverflow.com/questions/224256/captcha-is-missing-in-data-explorer-when-connected-over-https).
