### PR TITLE
Don't break all the things when sidebar is hidden on load

### DIFF
--- a/App/StackExchange.DataExplorer/Content/codemirror/custom.css
+++ b/App/StackExchange.DataExplorer/Content/codemirror/custom.css
@@ -17,3 +17,6 @@
     overflow: visible;
 }
 
+.CodeMirror-scroll {
+  height: 480px;
+}

--- a/App/StackExchange.DataExplorer/Scripts/query.sidebar.js
+++ b/App/StackExchange.DataExplorer/Scripts/query.sidebar.js
@@ -11,6 +11,8 @@
         panels = panel.add(o.toolbar);
         toggle = panels.find('#schema-toggle').on('click', toggleSidebar);
 
+        initSchema();
+
         if (DataExplorer.options.User.isAuthenticated) {
             sidebarPreference = new DataExplorer.DeferredRequest({
                 'url': '/users/save-preference/:id/HideSchema'.format({
@@ -22,8 +24,6 @@
                 toggleSidebar(false, true);
             }
         }
-
-        initSchema();
     }
 
     function initSchema() {


### PR DESCRIPTION
If we hide the sidebar before initializing it, things get unhappy...so don't do that. Also set a default height for the editor such that there isn't a difference on load between the collapsed/expanded sidebar view.
