### PR TITLE
Make sure a show event gets triggered on the currently selected panel on subsequent queries or we get nothing

### DIFF
--- a/App/StackExchange.DataExplorer/Scripts/query.js
+++ b/App/StackExchange.DataExplorer/Scripts/query.js
@@ -573,7 +573,7 @@ DataExplorer.ready(function () {
                 selectedTab = firstTab;
             }
 
-            selectedTab.click();
+            selectedTab.removeClass('youarehere').click();
 
             var height = 0,
                 maxHeight = 500;


### PR DESCRIPTION
Unbelievably stupid mistake on my part, sigh...If you've already run a query, calling `.click()` on the already-selected tab won't trigger a `show` event on the panel, which means the deferred render doesn't get run and the panel ends up blank (results/graph).

Quick fix is just removing the class before calling click so the expected events happen and everything's happy. Sorry about that. :/