### PR TITLE
Easily link to other queries in results

### DIFF
--- a/App/StackExchange.DataExplorer/Scripts/query.js
+++ b/App/StackExchange.DataExplorer/Scripts/query.js
@@ -527,7 +527,10 @@ DataExplorer.ready(function () {
                     gridPanel.append(document.create('div', { className: 'subpanel' }));
                     grids.push(new DataExplorer.ResultSet(
                         response.resultSets[i],
-                        response.url,
+                        {
+                            url: response.url,
+                            name: response.siteName
+                        },
                         '#resultSets .subpanel:nth-child(' + (i + 1) + ')'
                     ));
                 }

--- a/App/StackExchange.DataExplorer/Scripts/query.resultset.js
+++ b/App/StackExchange.DataExplorer/Scripts/query.resultset.js
@@ -84,9 +84,9 @@
         }
     }
 
-    function ColumnFormatter(resultSet, url) {
-        var base = url,
-            autolinker = /^(https?|site):\/\/[-A-Z0-9+&@#\/%?=~_\[\]\(\)!:,\.;]*[-A-Z0-9+&@#\/%=~_\[\]](?:\|.+?)?$/i,
+    function ColumnFormatter(resultSet, siteInfo) {
+        var base = siteInfo.url,
+            autolinker = /^(https?|site|query):\/\/[-A-Z0-9+&@#\/%?=~_\[\]\(\)!:,\.;]*[-A-Z0-9+&@#\/%=~_\[\]](?:\|.+?)?$/i,
             dummy = document.createElement('a'),
             wrapper = dummy,
             _outerHTML = 'outerHTML';
@@ -157,6 +157,9 @@
                     } else {
                         url = base + url;
                     }
+                } else if (matches[1] === 'query') {
+                    url = url.substring('query://'.length);
+                    url = '/' + siteInfo.name + '/query/' + url;
                 }
 
                 dummy.setAttribute('href', url);

--- a/App/StackExchange.DataExplorer/Views/Home/Help.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Home/Help.cshtml
@@ -124,6 +124,10 @@
             columns, like a particular post's revision history:
         </p>
         <pre class="cm-s-default"><span class="cm-sql-keyword">SELECT</span><br>  <span class="cm-sql-literal">'site://posts/'</span> <span class="cm-sql-operator">+</span> <span class="cm-sql-function">CAST</span>(<span class="cm-sql-word">Id</span> <span class="cm-sql-keyword">AS</span> <span class="cm-sql-type">nvarchar</span>) <span class="cm-sql-operator">+</span> <span class="cm-sql-literal">'/revisions|'</span> <span class="cm-sql-operator">+</span> <br>  <span class="cm-sql-literal">'Revision History for Post '</span> <span class="cm-sql-operator">+</span>  <span class="cm-sql-function">CAST</span>(<span class="cm-sql-word">Id</span> <span class="cm-sql-keyword">AS</span> <span class="cm-sql-type">nvarchar</span>) <span class="cm-sql-keyword">AS</span> <span class="cm-sql-word">[Revision Link</span><span class="cm-sql-word">]</span><br><span class="cm-sql-keyword">FROM</span> <span class="cm-sql-word">Posts</span> <span class="cm-sql-keyword">WHERE</span> <span class="cm-sql-word">Id</span> <span class="cm-sql-operator">=</span> <span class="cm-sql-special">##PostId##</span></pre>
+        <p>
+            Data Explorer also supports the custom scheme <code>query://&lt;id&gt;</code> to link to other queries, enabling you to link
+            directly to drill-downs or related queries from your results.
+        </p>
         <h2 id="graphing">Graphing</h2>
         <p>
             Being able to generate result sets is nice, but sometimes the output is more effectively conveyed as a graph. Data Explorer


### PR DESCRIPTION
Per [this Meta discussion](http://meta.stackexchange.com/questions/245814/magic-sede-syntax-akin-to-site-for-linking-to-http-data-stackexchang), add ability to link to another Data Explorer query run against the currently-selected site via the custom `query://<id>` scheme.