### PR TITLE
Fix grid text selection in Firefox

### DIFF
--- a/App/StackExchange.DataExplorer/Scripts/slick.grid.js
+++ b/App/StackExchange.DataExplorer/Scripts/slick.grid.js
@@ -2273,7 +2273,11 @@ if (typeof Slick === "undefined") {
         // don't steal it back - keyboard events will still bubble up
         // IE9+ seems to default DIVs to tabIndex=0 instead of -1, so check for cell clicks directly.
         if (e.target != document.activeElement || $(e.target).hasClass("slick-cell")) {
+          var selection = getTextSelection(); //store text-selection and restore it after
           setFocus();
+          if ( options.enableTextSelectionOnCells ) {
+            setTextSelection(selection);
+          }
         }
       }
 
@@ -2451,6 +2455,23 @@ if (typeof Slick === "undefined") {
         $focusSink[0].focus();
       } else {
         $focusSink2[0].focus();
+      }
+    }
+
+    //This get/set methods are used for keeping text-selection. These don't consider IE because they don't loose text-selection.
+    function getTextSelection(){
+      var selection = null;
+      if (window.getSelection && window.getSelection().rangeCount > 0) {
+        selection = window.getSelection().getRangeAt(0);
+      }
+      return selection;
+    }
+
+    function setTextSelection(selection){
+      if (window.getSelection && selection) {
+        var target = window.getSelection();
+        target.removeAllRanges();
+        target.addRange(selection);
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Once done, you'll need to populate the `Sites` table with a record for each site
 
  - [ASP.NET MVC 3](http://www.asp.net/mvc/mvc3)
  - [MiniProfiler](http://nuget.org/packages/MiniProfiler)
- - [Dapper](https://github.com/SamSaffron/dapper-dot-net)
+ - [Dapper](https://github.com/StackExchange/dapper-dot-net)
  - [jQuery](http://jquery.com/)
  - [CodeMirror](http://codemirror.net/)
- - [SlickGrid](https://github.com/mleibman/SlickGrid)
+ - [SlickGrid](https://github.com/mleibman/SlickGrid) (currently using [a fork](https://github.com/tms/SlickGrid) for updates)
  - [Flot](http://www.flotcharts.org/)
  - [Elmah](http://code.google.com/p/elmah/)
  - [Json.NET](http://james.newtonking.com/json)


### PR DESCRIPTION
SlickGrid [has an open bug](https://github.com/mleibman/SlickGrid/issues/739) that prevents text selection from working correctly in Firefox. Since the maintainer is MIA for the time being I made a fork and merged a pending PR that addresses the issue, then updated Data Explorer accordingly.

Fixes [this bug on Meta](http://meta.stackexchange.com/questions/247709/unable-to-select-values-from-data-explorer-results-firefox-bug-only).