### PR TITLE
Add bypass cache option to query screen

### DIFF
--- a/App/StackExchange.DataExplorer/AppSettings.cs
+++ b/App/StackExchange.DataExplorer/AppSettings.cs
@@ -51,6 +51,9 @@ namespace StackExchange.DataExplorer
         [Default(true)]
         public static bool EnableCancelQuery { get; private set; }
 
+        [Default(false)]
+        public static bool EnableClearCache { get; private set; }
+
         [Default("")]
         public static string RecaptchaPublicKey { get; private set; }
 

--- a/App/StackExchange.DataExplorer/AppSettings.cs
+++ b/App/StackExchange.DataExplorer/AppSettings.cs
@@ -52,7 +52,7 @@ namespace StackExchange.DataExplorer
         public static bool EnableCancelQuery { get; private set; }
 
         [Default(false)]
-        public static bool EnableClearCache { get; private set; }
+        public static bool EnableBypassCache { get; private set; }
 
         [Default("")]
         public static string RecaptchaPublicKey { get; private set; }

--- a/App/StackExchange.DataExplorer/Controllers/QueryController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/QueryController.cs
@@ -62,7 +62,7 @@ namespace StackExchange.DataExplorer.Controllers
 
         [HttpPost]
         [StackRoute(@"query/save/{siteId:\d+}/{querySetId?:\d+}")]
-        public ActionResult Save(string sql, string title, string description, int siteId, int? querySetId, bool? textResults, bool? withExecutionPlan, TargetSites? targetSites)
+        public ActionResult Save(string sql, string title, string description, int siteId, int? querySetId, bool? textResults, bool? withExecutionPlan, bool? bypassCache, TargetSites? targetSites)
         {
             if (CurrentUser.IsAnonymous && !CaptchaController.CaptchaPassed(GetRemoteIP()))
             {
@@ -95,6 +95,11 @@ namespace StackExchange.DataExplorer.Controllers
                     withExecutionPlan == true,
                     targetSites ?? TargetSites.Current
                 );
+
+                if (AppSettings.EnableClearCache && bypassCache.HasValue && bypassCache.Value)
+                {
+                    QueryUtil.ClearCachedResults(parsedQuery, siteId);
+                }
 
                 QueryResults results = null;
                 Site site = GetSite(siteId);
@@ -286,7 +291,7 @@ select @newId, RevisionId from QuerySetRevisions where QuerySetId = @oldId", new
 
         [HttpPost]
         [StackRoute(@"query/run/{siteId:\d+}/{querySetId:\d+}/{revisionId:\d+}")]
-        public ActionResult Execute(int querySetId, int revisionId, int siteId, bool? textResults, bool? withExecutionPlan, TargetSites? targetSites)
+        public ActionResult Execute(int querySetId, int revisionId, int siteId, bool? textResults, bool? withExecutionPlan, bool? bypassCache, TargetSites? targetSites)
         {
             if (CurrentUser.IsAnonymous && !CaptchaController.CaptchaPassed(GetRemoteIP()))
             {
@@ -325,6 +330,11 @@ select @newId, RevisionId from QuerySetRevisions where QuerySetId = @oldId", new
                     withExecutionPlan == true,
                     targetSites ?? TargetSites.Current
                 );
+
+                if (AppSettings.EnableClearCache && bypassCache.HasValue && bypassCache.Value)
+                {
+                    QueryUtil.ClearCachedResults(parsedQuery, siteId);
+                }
 
                 QueryResults results = null;
                 Site site = GetSite(siteId);

--- a/App/StackExchange.DataExplorer/Controllers/QueryController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/QueryController.cs
@@ -96,7 +96,7 @@ namespace StackExchange.DataExplorer.Controllers
                     targetSites ?? TargetSites.Current
                 );
 
-                if (AppSettings.EnableClearCache && bypassCache.HasValue && bypassCache.Value)
+                if (AppSettings.EnableBypassCache && bypassCache.HasValue && bypassCache.Value)
                 {
                     QueryUtil.ClearCachedResults(parsedQuery, siteId);
                 }
@@ -331,7 +331,7 @@ select @newId, RevisionId from QuerySetRevisions where QuerySetId = @oldId", new
                     targetSites ?? TargetSites.Current
                 );
 
-                if (AppSettings.EnableClearCache && bypassCache.HasValue && bypassCache.Value)
+                if (AppSettings.EnableBypassCache && bypassCache.HasValue && bypassCache.Value)
                 {
                     QueryUtil.ClearCachedResults(parsedQuery, siteId);
                 }

--- a/App/StackExchange.DataExplorer/Helpers/QueryUtil.cs
+++ b/App/StackExchange.DataExplorer/Helpers/QueryUtil.cs
@@ -87,7 +87,7 @@ order by qr.Id asc", new {querySetId}).ToList();
             {
                 if (cache.CreationDate.Value.AddMinutes(AppSettings.AutoExpireCacheMinutes) < DateTime.UtcNow)
                 {
-                    ClearCachedResults(cache.Id);
+                    Current.DB.Execute("DELETE CachedResults WHERE Id = @id", new { id = cache.Id });
 
                     cache = null;
                 }
@@ -108,10 +108,8 @@ order by qr.Id asc", new {querySetId}).ToList();
                 return;
             }
 
-            var cache = Current.DB.Query<CachedResult>(@"
-                SELECT
-                    *
-                FROM
+            Current.DB.Query<CachedResult>(@"
+                DELETE
                     CachedResults
                 WHERE
                     QueryHash = @hash AND
@@ -121,17 +119,7 @@ order by qr.Id asc", new {querySetId}).ToList();
                     hash = query.ExecutionHash,
                     site = siteId
                 }
-            ).FirstOrDefault();
-
-            if (cache != null)
-            {
-                ClearCachedResults(cache.Id);
-            }
-        }
-
-        private static void ClearCachedResults(int cacheId)
-        {
-            Current.DB.Execute("DELETE CachedResults WHERE Id = @id", new { id = cacheId });
+            );
         }
 
         public static Revision GetMigratedRevision(int id, MigrationType type)

--- a/App/StackExchange.DataExplorer/Views/Shared/Query.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Shared/Query.cshtml
@@ -45,6 +45,10 @@
                 Options:
                 <label title="Return results in text format"><input type="checkbox" name="textResults" value="true" />Text-only results</label>
                 <label title="Include the execution plan for this query in the results"><input type="checkbox" name="withExecutionPlan" value="true" />Include execution plan</label>
+                @if (AppSettings.EnableClearCache)
+                {
+                <label title="Ignore previously cached results"><input type="checkbox" name="bypassCache" value="true" />Bypass cache</label>
+                }
             @if (AppSettings.AllowRunOnAllDbsOption)
             {
                 <label title="Targe sites">Run on: 

--- a/App/StackExchange.DataExplorer/Views/Shared/Query.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Shared/Query.cshtml
@@ -45,7 +45,7 @@
                 Options:
                 <label title="Return results in text format"><input type="checkbox" name="textResults" value="true" />Text-only results</label>
                 <label title="Include the execution plan for this query in the results"><input type="checkbox" name="withExecutionPlan" value="true" />Include execution plan</label>
-                @if (AppSettings.EnableClearCache)
+                @if (AppSettings.EnableBypassCache)
                 {
                 <label title="Ignore previously cached results"><input type="checkbox" name="bypassCache" value="true" />Bypass cache</label>
                 }

--- a/App/StackExchange.DataExplorer/appSettings.config
+++ b/App/StackExchange.DataExplorer/appSettings.config
@@ -15,6 +15,7 @@
     <!--<add key="AllowExcludeMetaOption" value="false"/>-->
     <!--<add key="AllowRunOnAllDbsOption" value="false"/>-->
     <!--<add key="EnableCancelQuery" value="true"/>-->
+    <!--<add key="EnableClearCache" value="false"/>-->
     <!--<add key="RecaptchaPublicKey" value=""/>-->
     <!--<add key="RecaptchaPrivateKey" value=""/>-->
     <!--<add key="AutoExpireCacheMinutes" value="-1"/>-->

--- a/App/StackExchange.DataExplorer/appSettings.config
+++ b/App/StackExchange.DataExplorer/appSettings.config
@@ -15,7 +15,7 @@
     <!--<add key="AllowExcludeMetaOption" value="false"/>-->
     <!--<add key="AllowRunOnAllDbsOption" value="false"/>-->
     <!--<add key="EnableCancelQuery" value="true"/>-->
-    <!--<add key="EnableClearCache" value="false"/>-->
+    <!--<add key="EnableBypassCache" value="false"/>-->
     <!--<add key="RecaptchaPublicKey" value=""/>-->
     <!--<add key="RecaptchaPrivateKey" value=""/>-->
     <!--<add key="AutoExpireCacheMinutes" value="-1"/>-->


### PR DESCRIPTION
This adds an optional checkbox to the query screen to clear the cached results before running a query.