### PR TITLE
Have a different color for sql-literal in CodeMirror theme

### DIFF
--- a/App/StackExchange.DataExplorer/Content/codemirror/theme.css
+++ b/App/StackExchange.DataExplorer/Content/codemirror/theme.css
@@ -19,7 +19,7 @@
 .cm-s-default span.cm-sql-number   { color: #008B8B; }
 .cm-s-default span.cm-sql-function { color: #CC00BB; }
 .cm-s-default span.cm-sql-keyword  { color: #0000FF; }
-.cm-s-default span.cm-sql-literal  { color: #008000; }
+.cm-s-default span.cm-sql-literal  { color: #C72929; }
 .cm-s-default span.cm-sql-word     { color: #000000; }
 .cm-s-default span.cm-sql-special  { color: #C78800; }
 


### PR DESCRIPTION
This solves: [Could we get different font colors for SEDE comments and strings?](https://meta.stackexchange.com/questions/293044/could-we-get-different-font-colors-for-sede-comments-and-strings)

based on the comments it was decided to go for color that is red-ish but not as red as in SSMS.

The other options with screenshots how it will look are mentioned [here](https://meta.stackexchange.com/a/293065/158100). This is the option called compromise.