### PR TITLE
changed the linkformatter to use the /q/ route instead of /questions/…

### DIFF
--- a/App/StackExchange.DataExplorer/Scripts/query.resultset.js
+++ b/App/StackExchange.DataExplorer/Scripts/query.resultset.js
@@ -118,7 +118,9 @@
                     case 'user':
                         return linkFormatter('/users/', siteColumnName);
                     case 'post':
-                        return linkFormatter('/questions/', siteColumnName);
+                        // use q instead of questions because q also works for answers
+                        // when oneboxed in a chatroom, questions does not.
+                        return linkFormatter('/q/', siteColumnName);
                     case 'suggestededit':
                         return linkFormatter('/suggested-edits/', siteColumnName);
                     case 'comment':


### PR DESCRIPTION
… because /q/ also works for answers when oneboxed in chat.

see https://meta.stackexchange.com/questions/293081/sede-post-link-magic-column-not-compatible-with-chat-one-boxing-for-answers 