### PR TITLE
Fix column widths for Date columns in textonly resultsets

### DIFF
--- a/App/StackExchange.DataExplorer.Tests/Helpers/TestQueryResults.cs
+++ b/App/StackExchange.DataExplorer.Tests/Helpers/TestQueryResults.cs
@@ -77,6 +77,39 @@ x
 
         }
 
+        [TestMethod]
+        public void TestToTextWithDateColumn()
+        {
+            QueryResults results = new QueryResults { Messages = @"1
+
+" };
+
+            ResultSet first = new ResultSet { MessagePosition = 0 };
+            first.Columns.Add(new ResultColumnInfo { Name = "date", Type = ResultColumnType.Date });
+            first.Columns.Add(new ResultColumnInfo { Name = "text", Type = ResultColumnType.Text });
+            first.Rows.Add(new List<object> { 1L , "hello" });
+            results.ResultSets.Add(first);
+
+            var transformed = results.ToTextResults();
+
+            Assert.AreEqual(true, transformed.TextOnly);
+
+            var expected = @"date                text
+------------------- -----
+1970-01-01 00:00:00 hello
+
+1
+
+";
+
+            var actual = string.Join("\r\n", transformed.Messages.Split('\n').Select(s => s.Trim()));
+
+
+            Assert.AreEqual(expected
+ , actual);
+
+        }
+
         private static QueryResults MockResults()
         {
             var rows = new List<List<object>> { new List<object>() };

--- a/App/StackExchange.DataExplorer/Helpers/QueryResults.cs
+++ b/App/StackExchange.DataExplorer/Helpers/QueryResults.cs
@@ -98,6 +98,9 @@ namespace StackExchange.DataExplorer.Helpers
     public class QueryResults
     {
         private const int MAX_TEXT_COLUMN_WIDTH = 512;
+        // based on this date format yyyy-MM-dd HH:mm:ss 
+        // you'll need 19 characters to align textresult columns
+        private const int DATE_COLUMN_WIDTH = 19; 
 
         private static readonly List<ResultColumnType> _nativeTypes =
             new List<ResultColumnType>
@@ -303,7 +306,8 @@ namespace StackExchange.DataExplorer.Helpers
                     {
                         if (col != null && resultSet.Columns[i].Type == ResultColumnType.Date)
                         {
-                            currentVal = Util.FromJavaScriptTime((long)col).ToString("yyyy-MM-dd HH:mm:ss");
+                            // if you change the format, also adapt DATE_COLUMN_WIDTH 
+                            currentVal = Util.FromJavaScriptTime((long)col).ToString("yyyy-MM-dd HH:mm:ss"); 
                         }
                         else
                         {
@@ -349,7 +353,20 @@ namespace StackExchange.DataExplorer.Helpers
                     int curLength;
                     if (_nativeTypes.Contains(resultSet.Columns[i].Type))
                     {
-                        curLength = col?.ToString().Length ?? 4;
+                        // Date is formatted later for textresults!
+                        if (col != null && resultSet.Columns[i].Type == ResultColumnType.Date)
+                        {
+                            // col contains a long 
+                            // for textresults it is formatted later
+                            // instead of taking its length
+                            // use the length that will come out after
+                            // the String.Format is applied
+                            curLength = DATE_COLUMN_WIDTH; 
+                        }
+                        else
+                        {
+                            curLength = col?.ToString().Length ?? 4;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
This fixes an issue where date columns in textonly resultset would not align properly because the content in the column isn't formatted as a date when the width is determined.

I added a const to have that fixed length value as opposed to using the length of the format string as that could in theory differ.

Includes a unittest to test this fix.

This PR fixes https://meta.stackexchange.com/questions/296896/sede-text-only-output-column-width-is-not-correct-for-datetime-columns 