### PR TITLE
Changed the behavior and wording of the favorite tooltip 

### DIFF
--- a/App/StackExchange.DataExplorer/Scripts/master.js
+++ b/App/StackExchange.DataExplorer/Scripts/master.js
@@ -174,7 +174,11 @@ DataExplorer.Voting = (function () {
     var id, error, counter, star,
         voted = false, pending = false;
 
+    var favoriteQueryTitle = "This is one of your favorite queries (click to undo)";
+    var nonFavoriteQueryTitle = "Click to mark as favorite query (click again to undo)";
+
     function init(target, revision, vote, readOnly) {
+        var count;
         target = $(target);
 
         if (readOnly) {
@@ -187,6 +191,27 @@ DataExplorer.Voting = (function () {
         star = target.find('span').click(click);
         counter = target.find('.favoritecount');
         error = target.find('.error-notification');
+
+        count = parseInt(counter.text());
+
+        updateFavorite(voted, count);
+    }
+
+    function updateFavorite(favorited, count) {
+
+        counter.text(count);
+
+        if (!favorited) {
+            counter.removeClass('favoritecount-selected');
+            star.removeClass('star-on');
+            star.addClass('star-off');
+            star.prop('title', nonFavoriteQueryTitle);
+        } else {
+            counter.addClass('favoritecount-selected');
+            star.removeClass('star-off');
+            star.addClass('star-on');
+            star.prop('title', favoriteQueryTitle);
+        }
     }
 
     function click(event) {
@@ -204,21 +229,13 @@ DataExplorer.Voting = (function () {
 
         $.post('/vote/' + id, { 'voteType': 'favorite' }, function (response) {
             if (typeof response === 'object' && response.success) {
-                var count = parseInt(counter.text());
+                var count;
 
                 voted = !voted;
+                count = parseInt(counter.text()) + (voted ? 1 : -1);
 
-                if (!voted) {
-                    counter.removeClass('favoritecount-selected');
-                    counter.text(count - 1);
-                    star.removeClass('star-on');
-                    star.addClass('star-off');
-                } else {
-                    counter.addClass('favoritecount-selected');
-                    counter.text(count + 1);
-                    star.removeClass('star-off');
-                    star.addClass('star-on');
-                }
+                updateFavorite(voted, count);
+                
             }
 
             pending = false;

--- a/App/StackExchange.DataExplorer/Views/Shared/QueryVoting.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Shared/QueryVoting.cshtml
@@ -1,7 +1,7 @@
 ﻿@model StackExchange.DataExplorer.ViewModel.QuerySetVoting
 
 <div id="query-voting">
-    <span title="This is a favorite query (click again to undo)" class="star-@(Model.HasVoted?"on":"off")"></span>
+    <span title="" class="star-@(Model.HasVoted?"on":"off")"></span>
     <div class="favoritecount"><strong class="@(Model.HasVoted?"favoritecount-selected":"")">@Model.TotalVotes</strong></div>
     <div class="error-notification supernovabg">
         <h2>


### PR DESCRIPTION
which is shown  on the detail screen of a query. This change makes it similar that what happens on SE proper.

Moved the tooltip text to the master.js and handle the selection of the correct text there. When you're not logged in no tooltip will be shown but I left the attribute explicit on the html markup.

This implements bug [Data Explorer shows “This is a favorite query” for unfavorited queries](https://meta.stackexchange.com/q/298075/158100)