### PR TITLE
Fix Internet Archive download link that's 404ing

### DIFF
--- a/App/StackExchange.DataExplorer/Views/Home/Help.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Home/Help.cshtml
@@ -22,7 +22,7 @@
             </p>
             <ul class="external-links">
                 <li><a href="https://github.com/StackExchange/StackExchange.DataExplorer"><i class="icon-github"></i>Contribute<sub>on github</sub></a></li>
-                <li><a href="https://archive.org/download/stackexchange/stackexchange_archive.torrent"><i class="icon-cloud-download"></i>Download<sub> data dumps</sub></a></li>
+                <li><a href="https://archive.org/download/stackexchange/"><i class="icon-cloud-download"></i>Download<sub> data dumps</sub></a></li>
                 <li><a href="https://api.stackexchange.com/"><i class="icon-beaker"></i>Develop<sub>with the API</sub></a></li>
             </ul>
         </div>


### PR DESCRIPTION
[Per a Meta bug report](https://meta.stackexchange.com/questions/298758/sede-download-link-returns-a-404)