### PR TITLE
Fix letter casing in URLFriendly method so Ÿ and ÿ aren't stripped out

### DIFF
--- a/App/StackExchange.DataExplorer/Helpers/HtmlUtilities.cs
+++ b/App/StackExchange.DataExplorer/Helpers/HtmlUtilities.cs
@@ -340,7 +340,7 @@ namespace StackExchange.DataExplorer.Helpers
                     {
                         sb.Append("n");
                     }
-                    else if ("ýŸ".Contains(s))
+                    else if ("ýÿ".Contains(s))
                     {
                         sb.Append("y");
                     }


### PR DESCRIPTION
Found this while adding the functionality to my own site. The bug results in `Ÿ` and `ÿ` being stripped from the result.

Jeff's original [post](https://meta.stackexchange.com/a/7696/39605) with this code has the character as `ÿ` as well.

