### PR TITLE
The meta url link updated

### DIFF
--- a/App/StackExchange.DataExplorer/Views/Tutorial/NextSteps.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Tutorial/NextSteps.cshtml
@@ -19,7 +19,7 @@
     in these diagrams</a>.
 </p>
 <p>
-    You can find some interesting queries in <a href="//meta.worldbuilding.stackexchange.com/a/2014/28">this
+    You can find some interesting queries in <a href="//worldbuilding.meta.stackexchange.com/a/2014/28">this
     list on one of our sites</a>. For <em>tons</em> of interesting queries and starting points for your own
     work, see the <a href="//data.stackexchange.com/meta.stackexchange/queries">queries written by other people</a>.
     That link takes you to queries written against Meta.SE; go to <a href="/">the full list</a> to choose your


### PR DESCRIPTION
to prevent https privacy errors after the meta subdomains were moved around

This fixes https://meta.stackexchange.com/q/330524/158100