### PR TITLE
Updated the license to cc-by-sa 4.0 if warranted

### DIFF
--- a/App/StackExchange.DataExplorer/Views/Shared/Master.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Shared/Master.cshtml
@@ -91,7 +91,7 @@
             </div>
             <div id="copyright">
                 site design / logo &copy; @DateTime.UtcNow.Year Stack Exchange Inc; 
-                user contributions licensed under <a href="http://creativecommons.org/licenses/by-sa/3.0/" rel="license">cc by-sa 3.0</a>
+                user contributions licensed under <a href="http://creativecommons.org/licenses/by-sa/4.0/" rel="license">cc by-sa 4.0</a>
                 with <a href="https://stackoverflow.blog/2009/06/attribution-required/" rel="license">attribution required</a>
             </div>
             <div id="revision">rev @GlobalApplication.AppRevision</div>


### PR DESCRIPTION
this fixes, if needed, https://meta.stackexchange.com/questions/338959/sede-footer-still-links-to-version-3-0-of-creative-commons-license