### PR TITLE
more than 1M queries on summary page, show number with smaller font size

### DIFF
--- a/App/StackExchange.DataExplorer/Content/site.css
+++ b/App/StackExchange.DataExplorer/Content/site.css
@@ -1472,6 +1472,10 @@ font-weight:bold;
   text-align:center;
 }
 
+.summarycount.bignum {
+  font-size: 300%;
+}
+
 .al  {
   text-align:left;
 }

--- a/App/StackExchange.DataExplorer/Views/QuerySet/Index.cshtml
+++ b/App/StackExchange.DataExplorer/Views/QuerySet/Index.cshtml
@@ -12,7 +12,7 @@
 @section SecondaryContent {
     <div id="sidebar">
         <div class="module">
-            <div class="summarycount al">@string.Format("{0:n0}", totalQueries)</div>
+            <div class="summarycount al @(totalQueries >= 1000000 ? "bignum" : "")">@string.Format("{0:n0}", totalQueries)</div>
             <p>@(totalQueries == 1 ? "query" : "queries")</p>
         </div>
         @if (qsc.IsValid)


### PR DESCRIPTION
Fixed [this bug](https://meta.stackexchange.com/q/339130/51)