### PR TITLE
Updated the license to cc-by-sa 4.0 in /help page

### DIFF
--- a/App/StackExchange.DataExplorer/Views/Home/Help.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Home/Help.cshtml
@@ -17,7 +17,7 @@
             <p>
                 The data available here is similar to the data you can find in the Stack Exchange data dumps that are hosted on
                 the <a href="https://archive.org/details/stackexchange">Internet Archive</a> and licensed under
-                <a href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>. Developers looking to build applications
+                <a href="http://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>. Developers looking to build applications
                 that run off Stack Exchange data may also want to check out the <a href="https://api.stackexchange.com/">Stack Exchange API</a>.
             </p>
             <ul class="external-links">


### PR DESCRIPTION
It solves the request: [SEDE help page still links to version 3.0 of Creative Commons license](https://meta.stackexchange.com/q/341903/312043)

Updated the license to cc-by-sa 4.0 in the [Data Explorer help page](https://data.stackexchange.com/help) page.