### PR TITLE
Update target framework to 4.7 (to fix TLS 1.2+)

### DIFF
--- a/App/StackExchange.DataExplorer/Web.config
+++ b/App/StackExchange.DataExplorer/Web.config
@@ -48,7 +48,7 @@
       </system.Web>
   -->
   <system.web>
-    <httpRuntime targetFramework="4.5" requestValidationMode="2.0" executionTimeout="120" />
+    <httpRuntime targetFramework="4.7" requestValidationMode="2.0" executionTimeout="120" />
     <compilation debug="true" targetFramework="4.5.1">
       <assemblies>
         <add assembly="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />


### PR DESCRIPTION
We want to use the the system default for TLS and pre-.NET 4.5, this wasn't so awesome. It changed [in .NET 4.7](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/retargeting/4.5-4.7#default-value-of-servicepointmanagersecurityprotocol-is-securityprotocoltypesystemdefault) to be more friendly.

Specifically, this was breaking OpenID providers that *only* allow TLS 1.2 and higher. [Including now our own OpenID provider](https://meta.stackexchange.com/questions/343302/tls-1-0-and-tls-1-1-removal-for-stack-exchange-services). Realistically, this is the only outbound call SEDE is making.