### PR TITLE
Update licensing references

### DIFF
--- a/App/StackExchange.DataExplorer/Views/Home/Help.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Home/Help.cshtml
@@ -11,14 +11,14 @@
             <p>
                 &hellip;an open source tool for running arbitrary queries against public data from the Stack Exchange network.
                 Features include collaborative query editing @if (AppSettings.EnableOdata)
-                { @("and") <a href="http://www.odata.org/">OData</a> @("endpoints")} for all graduated
+                { @("and") <a href="https://www.odata.org/">OData</a> @("endpoints")} for all graduated
                 and public beta Stack Exchange sites.
             </p>
             <p>
                 The data available here is similar to the data you can find in the Stack Exchange data dumps that are hosted on
-                the <a href="https://archive.org/details/stackexchange">Internet Archive</a> and licensed under
-                <a href="http://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>. Developers looking to build applications
-                that run off Stack Exchange data may also want to check out the <a href="https://api.stackexchange.com/">Stack Exchange API</a>.
+                the <a href="https://archive.org/details/stackexchange">Internet Archive</a> and is licensed under
+                <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>. See the <a href="https://stackoverflow.com/help/licensing">licensing help page</a> for more info. 
+                Developers looking to build applications that run off Stack Exchange data may also want to check out the <a href="https://api.stackexchange.com/">Stack Exchange API</a>.
             </p>
             <ul class="external-links">
                 <li><a href="https://github.com/StackExchange/StackExchange.DataExplorer"><i class="icon-github"></i>Contribute<sub>on github</sub></a></li>

--- a/App/StackExchange.DataExplorer/Views/Shared/Master.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Shared/Master.cshtml
@@ -91,7 +91,7 @@
             </div>
             <div id="copyright">
                 site design / logo &copy; @DateTime.UtcNow.Year Stack Exchange Inc; 
-                user contributions licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="license">cc by-sa</a>; see <a href="https://stackoverflow.com/help/licensing">licensing help page</a> for more info
+                user contributions licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="license">cc by-sa</a>; see the <a href="https://stackoverflow.com/help/licensing">licensing help page</a> for more info
             </div>
             <div id="revision">rev @GlobalApplication.AppRevision</div>
         </div>

--- a/App/StackExchange.DataExplorer/Views/Shared/Master.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Shared/Master.cshtml
@@ -83,16 +83,15 @@
                 <a href="/about">help</a>
                 <a href="https://stackexchange.com/sites">sites</a>
                 <a href="https://stackoverflow.blog/">blog</a>
-                <a href="http://chat.stackexchange.com/rooms/13526/sede-stack-exchange-data-explorer">chat</a>
+                <a href="https://chat.stackexchange.com/rooms/13526/sede-stack-exchange-data-explorer">chat</a>
                 <a href="https://data.stackexchange.com">data</a>
                 <a href="https://stackexchange.com/legal">legal</a>
-                <strong><a href="http://meta.stackexchange.com/contact">contact us</a></strong>
-                <strong><a href="http://meta.stackexchange.com">feedback</a></strong>
+                <strong><a href="https://meta.stackexchange.com/contact">contact us</a></strong>
+                <strong><a href="https://meta.stackexchange.com">feedback</a></strong>
             </div>
             <div id="copyright">
                 site design / logo &copy; @DateTime.UtcNow.Year Stack Exchange Inc; 
-                user contributions licensed under <a href="http://creativecommons.org/licenses/by-sa/4.0/" rel="license">cc by-sa 4.0</a>
-                with <a href="https://stackoverflow.blog/2009/06/attribution-required/" rel="license">attribution required</a>
+                user contributions licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="license">cc by-sa</a>; see <a href="https://stackoverflow.com/help/licensing">licensing help page</a> for more info
             </div>
             <div id="revision">rev @GlobalApplication.AppRevision</div>
         </div>


### PR DESCRIPTION
- Update references to our licensing policy
- `http` to `https` on some links