### PR TITLE
StackApps Auth

### DIFF
--- a/App/StackExchange.DataExplorer/AppSettings.cs
+++ b/App/StackExchange.DataExplorer/AppSettings.cs
@@ -89,6 +89,15 @@ namespace StackExchange.DataExplorer
 
         public static bool EnableGoogleLogin => GoogleOAuthClientId.HasValue() && GoogleOAuthSecret.HasValue();
 
+        [Default("")]
+        public static string StackAppsClientId { get; private set; }
+        [Default("")]
+        public static string StackAppsOAuthSecret { get; private set; }
+        [Default("stackoverflow.com")]
+        public static string StackAppsDomain { get; private set; }
+        private static string _stackAppsAuthUrl;
+        public static string StackAppsAuthUrl => _stackAppsAuthUrl ?? (_stackAppsAuthUrl = "https://" + StackAppsDomain + "/oauth");
+        public static bool EnableStackAppsAuth => StackAppsClientId.HasValue() && StackAppsOAuthSecret.HasValue() && StackAppsDomain.HasValue();
 
         public enum AuthenitcationMethod
         {

--- a/App/StackExchange.DataExplorer/AppSettings.cs
+++ b/App/StackExchange.DataExplorer/AppSettings.cs
@@ -97,7 +97,12 @@ namespace StackExchange.DataExplorer
         public static string StackAppsDomain { get; private set; }
         private static string _stackAppsAuthUrl;
         public static string StackAppsAuthUrl => _stackAppsAuthUrl ?? (_stackAppsAuthUrl = "https://" + StackAppsDomain + "/oauth");
-        public static bool EnableStackAppsAuth => StackAppsClientId.HasValue() && StackAppsOAuthSecret.HasValue() && StackAppsDomain.HasValue();
+        [Default("")]
+        public static string StackAppsApiKey { get; private set; }
+        public static bool EnableStackAppsAuth => StackAppsClientId.HasValue() && StackAppsOAuthSecret.HasValue() && StackAppsDomain.HasValue() && StackAppsApiKey.HasValue();
+        [Default("api.stackexchange.com")]
+        public static string StackExchangeApiDomain { get; private set; }
+
 
         public enum AuthenitcationMethod
         {

--- a/App/StackExchange.DataExplorer/AppSettings.cs
+++ b/App/StackExchange.DataExplorer/AppSettings.cs
@@ -102,6 +102,8 @@ namespace StackExchange.DataExplorer
         public static bool EnableStackAppsAuth => StackAppsClientId.HasValue() && StackAppsOAuthSecret.HasValue() && StackAppsDomain.HasValue() && StackAppsApiKey.HasValue();
         [Default("api.stackexchange.com")]
         public static string StackExchangeApiDomain { get; private set; }
+        [Default("")]
+        public static string StackExchangeSyntheticIdPrefix { get; private set; }
 
 
         public enum AuthenitcationMethod

--- a/App/StackExchange.DataExplorer/Controllers/AccountController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/AccountController.cs
@@ -22,6 +22,7 @@ namespace StackExchange.DataExplorer.Controllers
     {
         private static readonly OpenIdRelyingParty OpenIdRelay = new OpenIdRelyingParty();
         const int GoogleAuthRetryAttempts = 3;
+        const int StackAppsAuthRetryAttempts = 3;
 
         [StackRoute("account/logout")]
         public ActionResult Logout()
@@ -556,7 +557,7 @@ namespace StackExchange.DataExplorer.Controllers
             postForm["client_secret"] = secret;
             postForm["redirect_uri"] = BaseUrl + path;
 
-            for (var retry = 0; retry < GoogleAuthRetryAttempts; retry++)
+            for (var retry = 0; retry < StackAppsAuthRetryAttempts; retry++)
             {
                 StackAppsAuthResponse authResponse;
                 try
@@ -596,7 +597,7 @@ namespace StackExchange.DataExplorer.Controllers
         {
             string result = null;
             Exception lastException = null;
-            for (var retry = 0; retry < GoogleAuthRetryAttempts; retry++)
+            for (var retry = 0; retry < StackAppsAuthRetryAttempts; retry++)
             {
                 try
                 {
@@ -623,7 +624,7 @@ namespace StackExchange.DataExplorer.Controllers
                 {
                     lastException = e;
                 }
-                if (retry == GoogleAuthRetryAttempts - 1)
+                if (retry == StackAppsAuthRetryAttempts - 1)
                     LogAuthError(lastException);
             }
 

--- a/App/StackExchange.DataExplorer/Controllers/AccountController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/AccountController.cs
@@ -231,7 +231,7 @@ namespace StackExchange.DataExplorer.Controllers
 
         private ActionResult LoginViaAccountId(string displayName, int accountId, string returnUrl)
         {
-            var syntheticId = Models.User.NormalizeOpenId($"https://stackauth.com/synthetic-open-id/stackexchange/{accountId}");
+            var syntheticId = Models.User.NormalizeOpenId($"{AppSettings.StackExchangeSyntheticIdPrefix}{accountId}");
 
             var openId = Current.DB.Query<UserOpenId>(
                 @"

--- a/App/StackExchange.DataExplorer/Views/Account/LogIn.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Account/LogIn.cshtml
@@ -24,12 +24,25 @@
                     <span>Log in using Facebook</span>
                 </p>
             </div>*@
-            <div class="preferred-login" data-provider='{ " name": "Stack Exchange", "url": "https://openid.stackexchange.com/" }'>
-                <p>
-                    <span class="icon" style="background-position: -356px 0;"></span>
-                    <span>Log in using Stack Exchange</span>
-                </p>
-            </div>
+
+            @if (AppSettings.EnableStackAppsAuth)
+            {
+                <div class="preferred-login" data-provider='{ " name": "Stack Overflow", "oauth2url": "@AppSettings.StackAppsAuthUrl" }'>
+                    <p>
+                        <span class="icon" style="background-position: -356px 0;"></span>
+                        <span>Log in using Stack Overflow</span>
+                    </p>
+                </div>
+            }
+            else
+            {
+                <div class="preferred-login" data-provider='{ " name": "Stack Exchange", "url": "https://openid.stackexchange.com/" }'>
+                    <p>
+                        <span class="icon" style="background-position: -356px 0;"></span>
+                        <span>Log in using Stack Exchange</span>
+                    </p>
+                </div>
+            }
         </div>
         <div>
             <noscript>

--- a/App/StackExchange.DataExplorer/appSettings.config
+++ b/App/StackExchange.DataExplorer/appSettings.config
@@ -35,4 +35,5 @@
     <!--<add key="StackAppsOAuthSecret" value="from stackapps.com/apps/oauth/view/{clientId}"/>-->
     <!--<add key="StackAppsApiKey" value="from stackapps.com/apps/oauth/view/{clientId}"/>-->
     <!--<add key="StackExchangeApiDomain" value="api.stackexchange.com" />-->
+    <!--<add key="StackExchangeSyntheticIdPrefix" value="https://example.com/stackexchange/accountId/" />-->
 </appSettings>

--- a/App/StackExchange.DataExplorer/appSettings.config
+++ b/App/StackExchange.DataExplorer/appSettings.config
@@ -28,4 +28,8 @@
     <!--<add key="OAuthSessionSalt" value=""/>-->
     <!--<add key="GoogleOAuthClientId" value=""/>-->
     <!--<add key="GoogleOAuthSecret" value=""/>-->
+    
+    <!--<add key="StackAppsClientId" value=""/>-->
+    <!--<add key="StackAppsOAuthSecret" value=""/>-->
+    <!--<add key="StackAppsDomain" value=""/>-->
 </appSettings>

--- a/App/StackExchange.DataExplorer/appSettings.config
+++ b/App/StackExchange.DataExplorer/appSettings.config
@@ -29,7 +29,10 @@
     <!--<add key="GoogleOAuthClientId" value=""/>-->
     <!--<add key="GoogleOAuthSecret" value=""/>-->
     
-    <!--<add key="StackAppsClientId" value=""/>-->
-    <!--<add key="StackAppsOAuthSecret" value=""/>-->
-    <!--<add key="StackAppsDomain" value=""/>-->
+
+    <!--<add key="StackAppsDomain" value="stackoverflow.com"/>-->
+    <!--<add key="StackAppsClientId" value="from stackapps.com/apps/oauth/view/{clientId}"/>-->
+    <!--<add key="StackAppsOAuthSecret" value="from stackapps.com/apps/oauth/view/{clientId}"/>-->
+    <!--<add key="StackAppsApiKey" value="from stackapps.com/apps/oauth/view/{clientId}"/>-->
+    <!--<add key="StackExchangeApiDomain" value="api.stackexchange.com" />-->
 </appSettings>


### PR DESCRIPTION
## Motivation

We're planning on retiring our public OpenID provider (openid.stackexchange.com) and SEDE is the last big-ish page that uses it.

## Description

This PR allows us to substitute the existing OpenID auth with a StackApp (https://stackapps.com). This will still allow users to log in via username and password, via the StackApps infrastructure.

An additional requirement for the user logging in via this method will be that they have an stackexchange.com account, so that they can allow the app to access their identity. We checked the existing credentials and most of them 5.7k out of 6k already do have an account.  We're going to run a manual mapping of those on the server, so the transition will be seamless.

Users will now have to enter their username and password on stackoverflow.com, and grant the SEDE StackApp rights to access their user.
