### PR TITLE
Connections: don't open by default

### DIFF
--- a/App/StackExchange.DataExplorer/Current.cs
+++ b/App/StackExchange.DataExplorer/Current.cs
@@ -164,7 +164,6 @@ namespace StackExchange.DataExplorer
                         cnn = new ProfiledDbConnection(cnn, new ErrorLoggingProfiler(profiler));
                     }
 
-                    cnn.Open();
                     result = DataExplorerDatabase.Create(cnn, 30);
                     if (Context != null)
                     {

--- a/App/StackExchange.DataExplorer/Current.cs
+++ b/App/StackExchange.DataExplorer/Current.cs
@@ -191,7 +191,7 @@ namespace StackExchange.DataExplorer
                 db?.Dispose();
                 Context.Items["DB"] = null;
             }
-            else
+            // Also clear the call context DB if we ever hit it in a background thread
             {
                 var db = CallContext.GetData("DB") as DataExplorerDatabase;
                 db?.Dispose();


### PR DESCRIPTION
In cases of background threads or breaks, this was leaving connections open and exhausting the pool. Instead, let Dapper handle it internally (it'll soft open and close as needed internally).