### PR TITLE
added css rules to handle overflow of oversized columnnames

### DIFF
--- a/App/StackExchange.DataExplorer/Content/site.css
+++ b/App/StackExchange.DataExplorer/Content/site.css
@@ -661,11 +661,13 @@ i.button {
 }
 
 #schema dl dt {
-  border-right: 1px dotted #CCCCCC;
-  float: left;
-  margin-left: 7px;
-  margin-right: 7px;
-  width: 55%;
+    border-right: 1px dotted #CCCCCC;
+    float: left;
+    margin-left: 7px;
+    margin-right: 7px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 60%;
 }
 
 #schema dl > * {

--- a/App/StackExchange.DataExplorer/Views/Query/Editor.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Query/Editor.cshtml
@@ -65,7 +65,7 @@
                 <dl>
                 @for (int i = 0; i < table.ColumnNames.Count; i++)
                 {
-                    <dt data-order="@i">@table.ColumnNames[i]</dt>
+                    <dt data-order="@i" title="@table.ColumnNames[i]">@table.ColumnNames[i]</dt>
                     <dd class="cm-variable-2">@table.DataTypes[i]</dd>
                 }
                 </dl>


### PR DESCRIPTION
 and add title attribute on the dt element so you can still see the full name of the column. 

This is a quick fix for https://meta.stackexchange.com/questions/353756/