### PR TITLE
Show the linenumber for SQL errors 

### DIFF
--- a/App/StackExchange.DataExplorer/Scripts/query.js
+++ b/App/StackExchange.DataExplorer/Scripts/query.js
@@ -610,13 +610,18 @@ DataExplorer.ready(function () {
     }
 
     function showError(response, className) {
+        var msg;
         if (response && !response.error) {
             error.hide();
 
             return false;
         }
-
-        error.text(response.error).show()[0].className = 'error-message' + (className || '');
+        if (response.line) {
+            msg = 'Line ' + response.line + ': ' + response.error;
+        } else {
+            msg = response.error;
+        }
+        error.text(msg).show()[0].className = 'error-message' + (className || '');
 
         return true;
     }


### PR DESCRIPTION
The linenumber is send to the client but never surfaced in the UI. This fix add the linenumber in front of the error message if the line property is present.

This implements:
https://meta.stackexchange.com/questions/239624/include-a-line-number-when-theres-a-syntax-error