### PR TITLE
added  a linked question mark icon in query view

### DIFF
--- a/App/StackExchange.DataExplorer/Views/Query/Editor.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Query/Editor.cshtml
@@ -45,8 +45,12 @@
         <textarea id="sql" name="sql" rows="26">@Html.Raw(sql)</textarea>
     </div>
     <div id="schema" class="right-group">
-        <span class="heading">Database Schema
+        <span class="heading">
+            Database Schema 
             <span class="buttons">
+                <span class="button-group">
+                    <a href="https://meta.stackexchange.com/q/2677"><i class="icon-question button" title="goto schema documentation"></i></a>
+                </span>
                 <span class="button-group">
                     <i class="icon-sort-by-alphabet button sort" title="sort alphabetically"></i>
                 </span>


### PR DESCRIPTION
in the schema div next to the Database schema title.

This implements https://meta.stackexchange.com/questions/51964/add-better-descriptions-and-e-r-diagram-to-data-explorers-schema

and

https://trello.com/c/mFQDy7v1/7-link-to-the-mse-schema-doc-from-somewhere-on-the-compose-query-page-perhaps-near-the-tables-list