### PR TITLE
a bit of logic to add text for switching between main and meta

### DIFF
--- a/App/StackExchange.DataExplorer/Views/Shared/Query.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Shared/Query.cshtml
@@ -71,22 +71,22 @@
         <div class="clear"></div>
     </form>
     <div id="site-selector" class="result-option">
-        Switch sites:
-        <ul>
-        @if (site.RelatedSite != null)
-        {
-            <li class="site-selector-related">
-                <a class="site templated @(site.SharesUsers(site.RelatedSite) ? "related-site" : "")" href="/@site.RelatedSite.TinyName.ToLower()/query/:id:slug:params" title="View results on @site.RelatedSite.LongName">
-                    <img class="site-icon" src="@site.RelatedSite.IconUrl" alt="@site.RelatedSite.LongName" />
-                </a>
-            </li>
-        }
-            <li>
-                <input id="switch-sites" type="text" size="24" placeholder="search by name or url" />
-            </li>
-        </ul>
-        <div class="clear"></div>
-    </div>
+        Switch @(site.RelatedSite == null ? "sites" : (site.ParentId == null) ? "to meta site" : "to main site"  )
+            <ul>
+                @if (site.RelatedSite != null)
+                {
+                    <li class="site-selector-related">
+                        <a class="site templated @(site.SharesUsers(site.RelatedSite) ? "related-site" : "")" href="/@site.RelatedSite.TinyName.ToLower()/query/:id:slug:params" title="View results on @site.RelatedSite.LongName">
+                            <img class="site-icon" src="@site.RelatedSite.IconUrl" alt="@site.RelatedSite.LongName" />
+                        </a>
+                    </li>
+                }
+                <li>
+                    <input id="switch-sites" type="text" size="24" placeholder="search by name or url" />
+                </li>
+            </ul>
+            <div class="clear"></div>
+        </div>
     <div id="loading">
         <img src="//cdn.sstatic.net/img/progress-dots.gif" alt="loading" /> Hold tight while we fetch your results
     </div>


### PR DESCRIPTION
This resolves 

https://meta.stackexchange.com/questions/169397/color-of-site-icons-on-stack-exchange-data-explorer-is-not-technically-incorrec

which did complain about a color being not correct but that was not the root cause as was worked out  in the comments. I've picked here the solution to add the word "main"and "meta" to clarify what the function of the icon meant, if there is one. You can argue for another 6 to 8 weeks about other options but this one is not plain dumb while still being easy to implement and resolves the confusion for by estimate 80 % of the users that click that icon.