### PR TITLE
somehow not adding the returnurl param went missing

### DIFF
--- a/App/StackExchange.DataExplorer/Views/Account/LogIn.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Account/LogIn.cshtml
@@ -49,7 +49,7 @@
                 <p class="noscript-notice">Open ID is a service that allows you to log on to many different websites using a single identity. Find out <a href="http://openid.net/what/">more about OpenId</a> and <a href="http://openid.net/get/">how to get an OpenID-enabled account</a>.</p>
             </noscript>
         </div>
-        <form class="openid-form" action="/user/authenticate" method="POST">
+        <form class="openid-form" action="/user/authenticate?returnurl=@Request.Params["returnurl"]" method="POST">
             <input type="hidden" id="oauth2url" name="@Keys.OAuth2Url" value="">
             <div class="small-buttons js-script-only">
                 <div>


### PR DESCRIPTION
this fixes  https://meta.stackexchange.com/questions/256042/sede-login-redirects-to-front-page-rather-than-returning

I've simply copied the build-up of the returnUrl query parameter as it was done in Views\Account\LogInActiveDirectory.cshtml

Tested with the SE OpenId provider. Any other provider that supports keeping the returnurl intact would work similar.