### PR TITLE
add an updatestatus on the index page

### DIFF
--- a/App/StackExchange.DataExplorer/Controllers/HomeController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/HomeController.cs
@@ -19,6 +19,14 @@ namespace StackExchange.DataExplorer.Controllers
 
             ViewData["LastUpdate"] = Current.DB.Query<DateTime?>("SELECT MAX(LastPost) FROM Sites").FirstOrDefault();
 
+            // sp_Refresh_Database https://gist.github.com/NickCraver/f009ab6e0d6b85ae54f6 
+            // will create a [name]_Temp database when the restore starts
+            // we rely on that implementation detail to determine if 
+            // a restore of data is in progress
+            ViewData["UpdateStatus"] = Current.DB.Query<string>(@"SELECT TOP 1 CASE WHEN [name] LIKE '%_Temp' THEN 'restoring' ELSE NULL END [status]
+FROM [sys].[databases] 
+ORDER BY [create_date] DESC").FirstOrDefault();
+
             return View(sites);
         }
 

--- a/App/StackExchange.DataExplorer/Views/Home/Index.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Home/Index.cshtml
@@ -3,7 +3,7 @@
 @{this.SetPageTitle("Stack Exchange Data Explorer");}
 <div id="mainbar-full">
     <div class="info-wrapper">
-        <span class="info">Data updated @((ViewData["LastUpdate"] as DateTime?).ToRelativeTime())</span>
+        <span class="info">Data updated @((ViewData["LastUpdate"] as DateTime?).ToRelativeTime()) <i>@(ViewData["UpdateStatus"])</i></span>
     </div>
     <ul class="site-list">
     @foreach (Site site in Model)


### PR DESCRIPTION
 queries sys.database so might need extra scrutiny for performance before merged because this get called for every fetch on /Index, basically the homepage. 

This fixes: https://meta.stackexchange.com/questions/315014/improvements-to-data-updated-x-hours-days-ago-message-in-sede