### PR TITLE
Authentication: fix insecure auth redirect

### DIFF
--- a/App/StackExchange.DataExplorer/Controllers/AccountController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/AccountController.cs
@@ -341,7 +341,7 @@ namespace StackExchange.DataExplorer.Controllers
 
         private ActionResult LoginError(string message) => RedirectToAction("Login", new {message});
 
-        private string BaseUrl => Current.Request.Url.Scheme + "://" + Current.Request.Url.Host;
+        private string BaseUrl => (Current.IsSecureConnection ? "https://" : "http://") + Current.Request.Url.Host;
 
         private ActionResult OAuthLogin()
         {


### PR DESCRIPTION
This resolves https://meta.stackexchange.com/questions/357811/chrome-warns-me-my-connection-is-not-secure-when-authenticating-in-sede-with-a-g, which was not using https:// when deployed behind a TLS terminator and the backend to web was over `:80`.