### PR TITLE
Add support for authenticating using Okta

### DIFF
--- a/App/StackExchange.DataExplorer/AppSettings.cs
+++ b/App/StackExchange.DataExplorer/AppSettings.cs
@@ -90,6 +90,17 @@ namespace StackExchange.DataExplorer
         public static bool EnableGoogleLogin => GoogleOAuthClientId.HasValue() && GoogleOAuthSecret.HasValue();
 
         [Default("")]
+        public static string OktaClientId { get; private set; }
+
+        [Default("")]
+        public static string OktaClientSecret { get; private set; }
+
+        [Default("")]
+        public static string OktaBaseUrl { get; private set; }
+
+        public static bool EnableOktaLogin => OktaClientId.HasValue() && OktaClientSecret.HasValue() && OktaBaseUrl.HasValue();
+
+        [Default("")]
         public static string StackAppsClientId { get; private set; }
         [Default("")]
         public static string StackAppsOAuthSecret { get; private set; }
@@ -104,7 +115,12 @@ namespace StackExchange.DataExplorer
         public static string StackExchangeApiDomain { get; private set; }
         [Default("")]
         public static string StackExchangeSyntheticIdPrefix { get; private set; }
-
+        [Default(true)]
+        public static bool EnableStackExchangeAuth { get; private set; }
+        [Default(true)]
+        public static bool EnableOpenIdAuth { get; private set; }
+        [Default(false)]
+        public static bool RequireAuthentication { get; private set; }
 
         public enum AuthenitcationMethod
         {

--- a/App/StackExchange.DataExplorer/Controllers/HomeController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/HomeController.cs
@@ -22,6 +22,13 @@ namespace StackExchange.DataExplorer.Controllers
             return View(sites);
         }
 
+        [StackRoute("ping")]
+        public ActionResult Ping()
+        {
+            Current.DB.Execute("SELECT 1");
+            return Content("pong");
+        }
+
         [StackRoute("help")]
         public ActionResult Help()
         {

--- a/App/StackExchange.DataExplorer/Controllers/StackOverflowController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/StackOverflowController.cs
@@ -98,7 +98,8 @@ namespace StackExchange.DataExplorer.Controllers
             ValidateRequest = false; // allow html/sql in form values - remember to validate!
             base.Initialize(requestContext);
 
-            if (AppSettings.EnableWhiteList && !(this is AccountController) && CurrentUser.IsAnonymous) {
+            var requireAuthentication = AppSettings.EnableWhiteList || AppSettings.RequireAuthentication;
+            if (requireAuthentication && !(this is AccountController) && CurrentUser.IsAnonymous) {
                 requestContext.HttpContext.Response.Redirect("/account/login?returnurl=" + Request.RawUrl);
             }
 

--- a/App/StackExchange.DataExplorer/Views/Account/LogIn.cshtml
+++ b/App/StackExchange.DataExplorer/Views/Account/LogIn.cshtml
@@ -9,41 +9,53 @@
     }
     <div class="js-openid-wrap">
         <div class="js-script-only">
-            @if (AppSettings.EnableGoogleLogin)
-            {
-                <div class="preferred-login" data-provider='{ "name": "Google", "oauth2url": "https://accounts.google.com/o/oauth2/auth" }'>
-                    <p>
-                        <span class="icon" style="background-position: -426px 0;"></span>
-                        <span>Log in using Google</span>
-                    </p>
-                </div>
-            }
-            @*<div class="preferred-login" data-provider='{ "name": "Facebook", "oauth2url": "https://www.facebook.com/v2.0/dialog/oauth" }'>
+        @if (AppSettings.EnableGoogleLogin)
+        {
+            <div class="preferred-login" data-provider='{ "name": "Google", "oauth2url": "https://accounts.google.com/o/oauth2/auth" }'>
+                <p>
+                    <span class="icon" style="background-position: -426px 0;"></span>
+                    <span>Log in using Google</span>
+                </p>
+            </div>
+        }
+
+        @if (AppSettings.EnableOktaLogin)
+        {
+            <div class="preferred-login" data-provider='{ "name": "Okta", "oauth2url": "@AppSettings.OktaBaseUrl/v1/authorize" }'>
+                <p>
+                    <span class="icon" style="background-position: -356px 0;"></span>
+                    <span>Log in using Okta</span>
+                </p>
+            </div>
+        }
+        @*<div class="preferred-login" data-provider='{ "name": "Facebook", "oauth2url": "https://www.facebook.com/v2.0/dialog/oauth" }'>
                 <p>
                     <span class="icon" style="background-position: -390px 0;"></span>
                     <span>Log in using Facebook</span>
                 </p>
             </div>*@
 
-            @if (AppSettings.EnableStackAppsAuth)
-            {
-                <div class="preferred-login" data-provider='{ " name": "Stack Overflow", "oauth2url": "@AppSettings.StackAppsAuthUrl" }'>
-                    <p>
-                        <span class="icon" style="background-position: -356px 0;"></span>
-                        <span>Log in using Stack Overflow</span>
-                    </p>
-                </div>
-            }
-            else
-            {
-                <div class="preferred-login" data-provider='{ " name": "Stack Exchange", "url": "https://openid.stackexchange.com/" }'>
-                    <p>
-                        <span class="icon" style="background-position: -356px 0;"></span>
-                        <span>Log in using Stack Exchange</span>
-                    </p>
-                </div>
-            }
-        </div>
+        @if (AppSettings.EnableStackAppsAuth)
+        {
+            <div class="preferred-login" data-provider='{ " name": "Stack Overflow", "oauth2url": "@AppSettings.StackAppsAuthUrl" }'>
+                <p>
+                    <span class="icon" style="background-position: -356px 0;"></span>
+                    <span>Log in using Stack Overflow</span>
+                </p>
+            </div>
+        }
+        else if (AppSettings.EnableStackExchangeAuth)
+        {
+            <div class="preferred-login" data-provider='{ " name": "Stack Exchange", "url": "https://openid.stackexchange.com/" }'>
+                <p>
+                    <span class="icon" style="background-position: -356px 0;"></span>
+                    <span>Log in using Stack Exchange</span>
+                </p>
+            </div>
+        }
+    </div>
+    @if (AppSettings.EnableOpenIdAuth)
+    {
         <div>
             <noscript>
                 <p class="noscript-notice">Open ID is a service that allows you to log on to many different websites using a single identity. Find out <a href="http://openid.net/what/">more about OpenId</a> and <a href="http://openid.net/get/">how to get an OpenID-enabled account</a>.</p>
@@ -90,7 +102,14 @@
                 </div>
             </div>
         </form>
-    </div>
+    }
+    else
+    {
+        <form class="openid-form" action="/user/authenticate" method="POST">
+            <input type="hidden" id="oauth2url" name="@Keys.OAuth2Url" value="">
+        </form>
+    }
+</div>
 </div>
 <script>
     var currentUrl, usernameBox = $(".openid-username");

--- a/App/StackExchange.DataExplorer/appSettings.config
+++ b/App/StackExchange.DataExplorer/appSettings.config
@@ -12,6 +12,7 @@
     <!--<add key="EnableEnforceSecureOpenId" value="false"/>-->
     <!--<add key="EnforceSecureOpenIdDefault" value="false"/>-->
     <!--<add key="EnableWhiteList" value="false"/>-->
+    <!--<add key="RequireAuthentication" value="true" />-->
     <!--<add key="AllowExcludeMetaOption" value="false"/>-->
     <!--<add key="AllowRunOnAllDbsOption" value="false"/>-->
     <!--<add key="EnableCancelQuery" value="true"/>-->
@@ -30,10 +31,17 @@
     <!--<add key="GoogleOAuthSecret" value=""/>-->
     
 
+    <!--<add key="OktaClientId" value="" />-->
+    <!--<add key="OktaClientSecret" value="" />-->
+    <!--<add key="OktaBaseUrl" value="" />-->
+  
     <!--<add key="StackAppsDomain" value="stackoverflow.com"/>-->
     <!--<add key="StackAppsClientId" value="from stackapps.com/apps/oauth/view/{clientId}"/>-->
     <!--<add key="StackAppsOAuthSecret" value="from stackapps.com/apps/oauth/view/{clientId}"/>-->
     <!--<add key="StackAppsApiKey" value="from stackapps.com/apps/oauth/view/{clientId}"/>-->
     <!--<add key="StackExchangeApiDomain" value="api.stackexchange.com" />-->
     <!--<add key="StackExchangeSyntheticIdPrefix" value="https://example.com/stackexchange/accountId/" />-->
+  
+    <!--<add key="EnableStackExchangeAuth" value="true" />-->
+    <!--<add key="EnableOpenIdAuth" value="true" />-->
 </appSettings>


### PR DESCRIPTION
This PR makes a few tweaks to add support for authenticating using Okta. It also includes the ability to disable OpenId authentication and legacy Stack Exchange authentication as well as adding the ability to require authentication (without requiring an allowlist of OpenIDs).

In order to test this you need to configure Okta with a client application and authorization server - I can provide those if needed.