### PR TITLE
Add Site Setting validation to CSV Routes

### DIFF
--- a/App/StackExchange.DataExplorer/Controllers/QueryController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/QueryController.cs
@@ -421,6 +421,11 @@ select @newId, RevisionId from QuerySetRevisions where QuerySetId = @oldId", new
 
         private ActionResult GetCsv(string sitename, int revisionId, TargetSites targetSites)
         {
+            if (!ValidateTargetSites(targetSites))
+            {
+                throw new ApplicationException("Invalid target sites selection");
+            }
+
             var query = QueryUtil.GetQueryForRevision(revisionId);
             if (query == null)
             {


### PR DESCRIPTION
Hello dearests!

We got an internal security report here at Stack Overflow that people are able to hit all websites with a query if they manually access the CSV routes. In local testing we've confirmed that's the case.

When looking at the code I've noticed that all CSV routes that are meant to query multiple websites do so using the GetCsv() helper method inside QueryController.cs. I've also noticed that such method is missing the ValidateTargetSites() check that other methods have in this Controller, so I've added it the same way to follow the pattern.

The goal is for those CSV routes to only be accessible if other multi-site routes also are, which in this case means having `AppSettings.AllowRunOnAllDbsOption`, which is checked by ValidateTargetSites().

Please let me know if you have a better idea to approach this issue.