### PR TITLE
PUBPLAT-3742 - Fail gracefully on error in GetCsv

### DIFF
--- a/App/StackExchange.DataExplorer/Controllers/QueryController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/QueryController.cs
@@ -423,7 +423,7 @@ select @newId, RevisionId from QuerySetRevisions where QuerySetId = @oldId", new
         {
             if (!ValidateTargetSites(targetSites))
             {
-                throw new ApplicationException("Invalid target sites selection");
+                return PageBadRequest();
             }
 
             var query = QueryUtil.GetQueryForRevision(revisionId);


### PR DESCRIPTION
Hello!

This is a simple one to replace validation result for TargetSites with a PageBadRequest() instead of a plain exception. Although other places in code throw an exception, those happen in POST requests, since GetCsv is a get request, it makes sense to fail more gracefully.

Recommended by our community in PUBPLAT-3742.