### PR TITLE
Source ParsedQuery key/value pairs from QueryString + Form instead of all Request.Params

### DIFF
--- a/App/StackExchange.DataExplorer/Controllers/QueryController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/QueryController.cs
@@ -87,7 +87,7 @@ namespace StackExchange.DataExplorer.Controllers
 
                 var parsedQuery = new ParsedQuery(
                     sql,
-                    Request.Params,
+                    UserParams,
                     withExecutionPlan == true,
                     targetSites ?? TargetSites.Current
                 );
@@ -307,7 +307,7 @@ select @newId, RevisionId from QuerySetRevisions where QuerySetId = @oldId", new
                 var query = Current.DB.Queries.Get(revision.QueryId);
                 var parsedQuery = new ParsedQuery(
                     query.QueryBody,
-                    Request.Params,
+                    UserParams,
                     withExecutionPlan == true,
                     targetSites ?? TargetSites.Current
                 );
@@ -371,7 +371,7 @@ select @newId, RevisionId from QuerySetRevisions where QuerySetId = @oldId", new
                     : RedirectPermanent($"/{site.TinyName.ToLower()}/csv/{revisionId}{(slug.HasValue() ? "/" + slug : "")}{Request.Url.Query}");
             }
 
-            var parsedQuery = new ParsedQuery(query.QueryBody, Request.Params);
+            var parsedQuery = new ParsedQuery(query.QueryBody, UserParams);
             if (!parsedQuery.IsExecutionReady)
             {
                 return PageBadRequest();
@@ -433,7 +433,7 @@ select @newId, RevisionId from QuerySetRevisions where QuerySetId = @oldId", new
             }
 
             var results = QueryRunner.GetResults(
-                new ParsedQuery(query.QueryBody, Request.Params, executionPlan: false, targetSites: targetSites),
+                new ParsedQuery(query.QueryBody, UserParams, executionPlan: false, targetSites: targetSites),
                 null,
                 CurrentUser
             );
@@ -511,7 +511,7 @@ select @newId, RevisionId from QuerySetRevisions where QuerySetId = @oldId", new
                     : RedirectPermanent($"/{site.TinyName.ToLower()}/plan/{revisionId}{(slug.HasValue() ? "/" + slug : "")}{Request.Url.Query}");
             }
 
-            var parsedQuery = new ParsedQuery(query.QueryBody, Request.Params);
+            var parsedQuery = new ParsedQuery(query.QueryBody, UserParams);
             if (!parsedQuery.IsExecutionReady)
             {
                 return PageBadRequest();

--- a/App/StackExchange.DataExplorer/Controllers/QuerySetController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/QuerySetController.cs
@@ -158,7 +158,7 @@ namespace StackExchange.DataExplorer.Controllers
             }
 
             CachedResult cachedResults = QueryUtil.GetCachedResults(
-                new ParsedQuery(revision.Query.QueryBody, Request.Params),
+                new ParsedQuery(revision.Query.QueryBody, UserParams),
                 Site.Id
             );
 

--- a/App/StackExchange.DataExplorer/Controllers/StackOverflowController.cs
+++ b/App/StackExchange.DataExplorer/Controllers/StackOverflowController.cs
@@ -199,6 +199,30 @@ namespace StackExchange.DataExplorer.Controllers
             base.OnActionExecuted(filterContext);
         }
 #endif
+
+        private NameValueCollection _userParams;
+
+        public NameValueCollection UserParams
+        {
+            get
+            {
+                if (_userParams == null) InitUserParams();
+                return _userParams;
+            }
+        }
+
+        protected void InitUserParams()
+        {
+            var combinedParams = new NameValueCollection(Request.QueryString);
+
+            foreach (string key in Request.Form)
+            {
+                combinedParams[key] = Request.Form[key];
+            }
+
+            _userParams = combinedParams;
+        }
+
         private User _currentUser;
         /// <summary>
         /// Gets a User object representing the current request's client.


### PR DESCRIPTION
I unfortunately don't have Data Explorer set up to verify these changes at the immediate moment, but as uncovered by [this Meta post](https://meta.stackexchange.com/questions/385634/sede-does-something-weird-with-url-parameters), we seed the variable substitution for `ParsedQuery` with the key/value pairs from `Request.Params`. 

`Request.Params` "[gets a combined collection of QueryString, Form, Cookies, and ServerVariables items](https://learn.microsoft.com/en-us/dotnet/api/system.web.httprequest.params?redirectedfrom=MSDN&view=netframework-4.8.1#System_Web_HttpRequest_Params)", which inadvertently makes it possible to dump cookie or IIS server variable values (in the case of the Meta post, it's a conflict with the server variable "url"). Not ideal!

This change puts the user supplied parameters we care about into a single property that we can then pass into `ParsedQuery` in various places. It's likely also possible to just use `Request.QueryString` or `Request.Form` as appropriate, but I felt less confident in that change since the current behaviour would mask if we had a route that allowed you to use both.